### PR TITLE
[added] usea execv and wait to list /tmp

### DIFF
--- a/holberton.h
+++ b/holberton.h
@@ -6,4 +6,5 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/wait.h>
 #endif

--- a/wait_execev.c
+++ b/wait_execev.c
@@ -1,0 +1,33 @@
+#include "holberton.h"
+
+int main(void)
+{
+	pid_t pid;
+	int times = 0, wstatus = 0;
+	char *args[] = {"ls","-l","/tmp",NULL};
+	char *env_args[] = {"PATH=/bin",NULL};
+
+	while (times < 5)
+	{
+		pid = fork();
+		if (pid == -1)
+		{
+			write(STDOUT_FILENO,"Error process\n",14);
+			return (-1);
+		}
+		else if(pid == 0)
+		{
+//			write(STDOUT_FILENO,"Soy el hijo\n",12);
+			if (execve("/bin/ls", args, env_args) == -1)
+			{
+				write(STDOUT_FILENO,"Error execv\n",12);
+				return (-1);
+			}
+		}
+		else{
+			waitpid(pid, &wstatus, 0);
+		}
+		times++;
+	}
+	return (0);
+}


### PR DESCRIPTION
Fixes #7 
Fixes #8 
Create the way to execute other program using execv
Conclusion: the fist argument of execv is the path where contains the program to execute,
i suggest research about stat.
Research about how to use correctly  *env[] variable